### PR TITLE
Change on_error_action value

### DIFF
--- a/modules/jcommunity/install/var/config/auth.coord.ini.php
+++ b/modules/jcommunity/install/var/config/auth.coord.ini.php
@@ -33,7 +33,7 @@ on_error = 2
 error_message = "jcommunity~login.error.notlogged"
 
 ; action to execute on a missing authentification when on_error=2
-on_error_action = "jcommunity~login:out"
+on_error_action = "jcommunity~login:in"
 
 ; action to execute when a bad ip is checked with secure_with_ip=1 and on_error=2
 bad_ip_action = "jcommunity~login:out"


### PR DESCRIPTION
By default : on_error = 2 and on_error_action = "jcommunity~login:out" create a infinity loop if you are not auth.
So on_error_action = "jcommunity~login:in" make redirect to login if not auth.
