### PR TITLE
adding possibility to not add default users during installation

### DIFF
--- a/modules/jcommunity/controllers/user.cmdline.php
+++ b/modules/jcommunity/controllers/user.cmdline.php
@@ -13,6 +13,7 @@ class userCtrl extends jControllerCmdLine {
             '--reset' => false,
             '--admin' => false,
             '-v' => false,
+            '--no-error-if-exists' => false
         )
     );
 
@@ -139,6 +140,7 @@ class userCtrl extends jControllerCmdLine {
         $reset = $this->option('--reset');
         $admin = $this->option('--admin');
         $verbose = $this->option('-v');
+        $error = $this->option('--no-error-if-exists');
         $code = 0;
         $message = '';
 
@@ -154,8 +156,8 @@ class userCtrl extends jControllerCmdLine {
             $code = 1;
         }
 
-        if ($code) {
-            return $this->exit($rep, $code, $message, $verbose);
+        if ($code) {            
+                return $this->exit($rep, $error ? 0 : $code, $message, $verbose);
         }
 
         if (!$password) {

--- a/modules/jcommunity/install/install.php
+++ b/modules/jcommunity/install/install.php
@@ -225,11 +225,15 @@ class jcommunityModuleInstaller extends \Jelix\Installer\Module\Installer {
 
         $file = $path.'install/'.$relativeSourcePath;
         $usersToInsert = json_decode(file_get_contents($file), true);
-        if (!$usersToInsert) {
+        if ($usersToInsert === null) {
             throw new Exception("jCommunity install: Bad format for users data file $relativeSourcePath.");
         }
         if (is_object($usersToInsert)) {
             $usersToInsert = array($usersToInsert);
+        }
+
+        if (empty($usersToInsert)) {
+            return ;
         }
 
         $dao = jDao::get($daoSelector, $dbProfile);

--- a/modules/jcommunity/install/install_1_6.php
+++ b/modules/jcommunity/install/install_1_6.php
@@ -277,11 +277,15 @@ class jcommunityModuleInstaller extends jInstallerModule {
 
         $file = $path.'install/'.$relativeSourcePath;
         $usersToInsert = json_decode(file_get_contents($file), true);
-        if (!$usersToInsert) {
+        if ($usersToInsert === null) {
             throw new Exception("jCommunity install: Bad format for users data file $relativeSourcePath.");
         }
         if (is_object($usersToInsert)) {
             $usersToInsert = array($usersToInsert);
+        }
+
+        if (empty($usersToInsert)) {
+            return ;
         }
 
         $dao = jDao::get($daoSelector, $dbProfile);


### PR DESCRIPTION
Now that we added scripts to generate and alter users and passwords, we can add the possibility to not add default users during installation.